### PR TITLE
Drop support for PHP 5.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 build/
 bin/
 composer.lock
+/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "symfony/dependency-injection": "^2.3 || ^3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0"
+        "phpunit/phpunit": "^9.0",
+        "yoast/phpunit-polyfills": "^1.0"
     },
     "config": {
         "bin-dir": "bin",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "php": ">=5.6",
+        "php": "^7.0 || ^8.0",
         "ext-bcmath": "*",
         "ext-mbstring": "*",
         "maba/math": "^1.0",
@@ -27,7 +27,7 @@
         "symfony/dependency-injection": "^2.3 || ^3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0",
+        "phpunit/phpunit": "^6.5 || ^9.6",
         "yoast/phpunit-polyfills": "^1.0"
     },
     "config": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
-    backupGlobals               = "false"
-    backupStaticAttributes      = "false"
-    colors                      = "true"
-    convertErrorsToExceptions   = "true"
-    convertNoticesToExceptions  = "true"
-    convertWarningsToExceptions = "true"
-    processIsolation            = "false"
-    stopOnFailure               = "false"
-    bootstrap                   = "vendor/autoload.php" >
-
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         colors="true">
     <testsuites>
-        <testsuite name="Project Test Suite">
+        <testsuite name="Money Test Suite">
             <directory>tests/</directory>
         </testsuite>
     </testsuites>
+
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </coverage>
 </phpunit>

--- a/tests/AggregatedMoneyTest.php
+++ b/tests/AggregatedMoneyTest.php
@@ -4,8 +4,9 @@ namespace Evp\Component\Money\Tests;
 
 use Evp\Component\Money\AggregatedMoney;
 use Evp\Component\Money\Money;
+use PHPUnit\Framework\TestCase;
 
-class AggregatedMoneyTest extends \PHPUnit_Framework_TestCase
+class AggregatedMoneyTest extends TestCase
 {
     /**
      * @param Money $one

--- a/tests/BcMathTest.php
+++ b/tests/BcMathTest.php
@@ -3,8 +3,9 @@
 namespace Evp\Component\Money\Tests;
 
 use Evp\Component\Money\BcMath;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
-class BcMathTest extends \PHPUnit_Framework_TestCase
+class BcMathTest extends TestCase
 {
     /**
      * @var \Evp\Component\Money\BcMath
@@ -14,7 +15,7 @@ class BcMathTest extends \PHPUnit_Framework_TestCase
     /**
      * Set up
      */
-    public function setUp()
+    public function set_up()
     {
         $this->math = new BcMath($scale = 6);
     }

--- a/tests/CurrencyIsoNumberTest.php
+++ b/tests/CurrencyIsoNumberTest.php
@@ -3,8 +3,10 @@
 namespace Evp\Component\Money\Tests;
 
 use Evp\Component\Money\CurrencyIsoNumber;
+use Evp\Component\Money\MoneyException;
+use PHPUnit\Framework\TestCase;
 
-class CurrencyIsoNumberTest extends \PHPUnit_Framework_TestCase
+class CurrencyIsoNumberTest extends TestCase
 {
     /**
      * @param string $currencyNumber
@@ -22,11 +24,10 @@ class CurrencyIsoNumberTest extends \PHPUnit_Framework_TestCase
      * @param string $currencyNumber
      *
      * @dataProvider getCurrencyCodeExceptionProvider
-     *
-     * @expectedException \Evp\Component\Money\MoneyException
      */
     public function testGetCurrencyCodeException($currencyNumber)
     {
+        $this->expectException(MoneyException::class);
         $currencyIsoNumber = new CurrencyIsoNumber();
         $currencyIsoNumber->getCurrencyCode($currencyNumber);
     }
@@ -47,11 +48,10 @@ class CurrencyIsoNumberTest extends \PHPUnit_Framework_TestCase
      * @param string $currencyCode
      *
      * @dataProvider getCurrencyNumberExceptionProvider
-     *
-     * @expectedException \Evp\Component\Money\MoneyException
      */
     public function testGetCurrencyNumberException($currencyCode)
     {
+        $this->expectException(MoneyException::class);
         $currencyIsoNumber = new CurrencyIsoNumber();
         $currencyIsoNumber->getCurrencyNumber($currencyCode);
     }

--- a/tests/MoneyComparator.php
+++ b/tests/MoneyComparator.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Evp\Component\Money\Tests;
+
+use Evp\Component\Money\Money;
+use SebastianBergmann\Comparator\Comparator;
+use SebastianBergmann\Comparator\ComparisonFailure;
+
+class MoneyComparator extends Comparator
+{
+
+    public function accepts($expected, $actual)
+    {
+        return $expected instanceof Money && $actual instanceof Money;
+    }
+
+    public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false)
+    {
+        assert($expected instanceof Money);
+        assert($actual instanceof Money);
+
+        if (!$expected->isEqual($actual)) {
+            throw new ComparisonFailure(
+                $expected,
+                $actual,
+                $expected->getAsString(),
+                $actual->getAsString(),
+                false,
+                'Failed asserting that two Money objects are equal.'
+            );
+        }
+    }
+}

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -3,15 +3,19 @@
 namespace Evp\Component\Money\Tests;
 
 use Evp\Component\Money\Money;
+use Evp\Component\Money\MoneyException;
+use Exception;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 
-class MoneyTest extends \PHPUnit_Framework_TestCase
+class MoneyTest extends TestCase
 {
     /**
      * Test add
      *
-     * @param \Evp\Component\Money\Money $operandOne
-     * @param \Evp\Component\Money\Money $operandTwo
-     * @param \Evp\Component\Money\Money $expected
+     * @param Money $operandOne
+     * @param Money $operandTwo
+     * @param Money $expected
      *
      * @dataProvider addProvider
      */
@@ -23,9 +27,9 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     /**
      * Test sub
      *
-     * @param \Evp\Component\Money\Money $operandOne
-     * @param \Evp\Component\Money\Money $operandTwo
-     * @param \Evp\Component\Money\Money $expected
+     * @param Money $operandOne
+     * @param Money $operandTwo
+     * @param Money $expected
      *
      * @dataProvider subProvider
      */
@@ -37,9 +41,9 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     /**
      * Test mul
      *
-     * @param \Evp\Component\Money\Money $operandOne
+     * @param Money $operandOne
      * @param string $multiplier
-     * @param \Evp\Component\Money\Money $expected
+     * @param Money $expected
      *
      * @dataProvider mulProvider
      */
@@ -51,9 +55,9 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     /**
      * Test div
      *
-     * @param \Evp\Component\Money\Money $operandOne
+     * @param Money $operandOne
      * @param string $divisor
-     * @param \Evp\Component\Money\Money $expected
+     * @param Money $expected
      *
      * @dataProvider divProvider
      */
@@ -65,49 +69,49 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     /**
      * Test add exception
      *
-     * @param \Evp\Component\Money\Money $operandOne
-     * @param \Evp\Component\Money\Money $operandTwo
+     * @param Money $operandOne
+     * @param Money $operandTwo
      *
-     * @expectedException \Evp\Component\Money\MoneyException
      * @dataProvider      addExceptionProvider
      */
     public function testAddException(Money $operandOne, Money $operandTwo)
     {
+        $this->expectException(MoneyException::class);
         $operandOne->add($operandTwo);
     }
 
     /**
      * Test sub exception
      *
-     * @param \Evp\Component\Money\Money $operandOne
-     * @param \Evp\Component\Money\Money $operandTwo
+     * @param Money $operandOne
+     * @param Money $operandTwo
      *
-     * @expectedException \Evp\Component\Money\MoneyException
      * @dataProvider      subExceptionProvider
      */
     public function testSubException(Money $operandOne, Money $operandTwo)
     {
+        $this->expectException(MoneyException::class);
         $operandOne->sub($operandTwo);
     }
 
     /**
      * Test div exception with division of zero
      *
-     * @param \Evp\Component\Money\Money $operandOne
+     * @param Money $operandOne
      *
-     * @expectedException \Evp\Component\Money\MoneyException
      * @dataProvider      divExceptionProvider
      */
     public function testDivException(Money $operandOne)
     {
+        $this->expectException(MoneyException::class);
         $operandOne->div(0);
     }
 
     /**
      * Test is equal
      *
-     * @param \Evp\Component\Money\Money $operandOne
-     * @param \Evp\Component\Money\Money $operandTwo
+     * @param Money $operandOne
+     * @param Money $operandTwo
      *
      * @dataProvider isEqualProvider
      */
@@ -119,8 +123,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     /**
      * Test is greater
      *
-     * @param \Evp\Component\Money\Money $operandOne
-     * @param \Evp\Component\Money\Money $operandTwo
+     * @param Money $operandOne
+     * @param Money $operandTwo
      *
      * @dataProvider isGtProvider
      */
@@ -132,8 +136,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     /**
      * Test is greater or equal
      *
-     * @param \Evp\Component\Money\Money $operandOne
-     * @param \Evp\Component\Money\Money $operandTwo
+     * @param Money $operandOne
+     * @param Money $operandTwo
      *
      * @dataProvider isGteProvider
      */
@@ -145,8 +149,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     /**
      * Test is less
      *
-     * @param \Evp\Component\Money\Money $operandOne
-     * @param \Evp\Component\Money\Money $operandTwo
+     * @param Money $operandOne
+     * @param Money $operandTwo
      *
      * @dataProvider isLtProvider
      */
@@ -158,8 +162,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     /**
      * Test is less or equal
      *
-     * @param \Evp\Component\Money\Money $operandOne
-     * @param \Evp\Component\Money\Money $operandTwo
+     * @param Money $operandOne
+     * @param Money $operandTwo
      *
      * @dataProvider isLteProvider
      */
@@ -171,64 +175,64 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     /**
      * Test is greater exception
      *
-     * @param \Evp\Component\Money\Money $operandOne
-     * @param \Evp\Component\Money\Money $operandTwo
+     * @param Money $operandOne
+     * @param Money $operandTwo
      *
      * @dataProvider      isGtExceptionProvider
-     * @expectedException \Evp\Component\Money\MoneyException
      */
     public function testIsGtException(Money $operandOne, Money $operandTwo)
     {
+        $this->expectException(MoneyException::class);
         $operandOne->isGt($operandTwo);
     }
 
     /**
      * Test is greater or equal exception
      *
-     * @param \Evp\Component\Money\Money $operandOne
-     * @param \Evp\Component\Money\Money $operandTwo
+     * @param Money $operandOne
+     * @param Money $operandTwo
      *
      * @dataProvider      isGteExceptionProvider
-     * @expectedException \Evp\Component\Money\MoneyException
      */
     public function testIsGteException(Money $operandOne, Money $operandTwo)
     {
+        $this->expectException(MoneyException::class);
         $operandOne->isGte($operandTwo);
     }
 
     /**
      * Test is less exception
      *
-     * @param \Evp\Component\Money\Money $operandOne
-     * @param \Evp\Component\Money\Money $operandTwo
+     * @param Money $operandOne
+     * @param Money $operandTwo
      *
      * @dataProvider      isLtExceptionProvider
-     * @expectedException \Evp\Component\Money\MoneyException
      */
     public function testIsLtException(Money $operandOne, Money $operandTwo)
     {
+        $this->expectException(MoneyException::class);
         $operandOne->isLt($operandTwo);
     }
 
     /**
      * Test is less or equal exception
      *
-     * @param \Evp\Component\Money\Money $operandOne
-     * @param \Evp\Component\Money\Money $operandTwo
+     * @param Money $operandOne
+     * @param Money $operandTwo
      *
      * @dataProvider      isLteExceptionProvider
-     * @expectedException \Evp\Component\Money\MoneyException
      */
     public function testIsLteException(Money $operandOne, Money $operandTwo)
     {
+        $this->expectException(MoneyException::class);
         $operandOne->isLte($operandTwo);
     }
 
     /**
      * Test is same currency
      *
-     * @param \Evp\Component\Money\Money $operandOne
-     * @param \Evp\Component\Money\Money $operandTwo
+     * @param Money $operandOne
+     * @param Money $operandTwo
      *
      * @dataProvider isSameCurrencyProvider
      */
@@ -240,8 +244,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     /**
      * Test negate
      *
-     * @param \Evp\Component\Money\Money $operandOne
-     * @param \Evp\Component\Money\Money $expected
+     * @param Money $operandOne
+     * @param Money $expected
      *
      * @dataProvider negateProvider
      */
@@ -253,7 +257,7 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     /**
      * Test format amount
      *
-     * @param \Evp\Component\Money\Money $operandOne
+     * @param Money $operandOne
      * @param int $precision
      * @param string $delimiter
      * @param string $thousandSeparator
@@ -269,8 +273,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     /**
      * Test ceil
      *
-     * @param \Evp\Component\Money\Money $operandOne
-     * @param \Evp\Component\Money\Money $expected
+     * @param Money $operandOne
+     * @param Money $expected
      * @param integer|null $precision
      *
      * @dataProvider ceilProvider
@@ -283,8 +287,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     /**
      * Test floor
      *
-     * @param \Evp\Component\Money\Money $operandOne
-     * @param \Evp\Component\Money\Money $expected
+     * @param Money $operandOne
+     * @param Money $expected
      * @param integer|null $precision
      *
      * @dataProvider floorProvider
@@ -297,8 +301,8 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     /**
      * Test round
      *
-     * @param \Evp\Component\Money\Money $operandOne
-     * @param \Evp\Component\Money\Money $expected
+     * @param Money $operandOne
+     * @param Money $expected
      *
      * @dataProvider roundProvider
      */
@@ -310,7 +314,7 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     /**
      * Test getAsString
      *
-     * @param \Evp\Component\Money\Money $operandOne
+     * @param Money $operandOne
      * @param string $expected
      *
      * @dataProvider getAsStringProvider
@@ -325,7 +329,7 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
      *
      * @param string $operandOnemount
      * @param string $currency
-     * @param \Evp\Component\Money\Money $expected
+     * @param Money $expected
      *
      * @dataProvider createFromNonDelimiterProvider
      */
@@ -338,7 +342,7 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
      * Test create zero
      *
      * @param string $currency
-     * @param \Evp\Component\Money\Money $expected
+     * @param Money $expected
      *
      * @dataProvider createZeroProvider
      */
@@ -367,10 +371,10 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
      * @param string $currency
      *
      * @dataProvider      setAmountExceptionProvider
-     * @expectedException \InvalidArgumentException
      */
     public function testSetAmountException($amount, $currency)
     {
+        $this->expectException(InvalidArgumentException::class);
         Money::create($amount, $currency);
     }
 
@@ -391,7 +395,7 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
      * @param string $currency
      *
      * @dataProvider createAmountInMinorUnitsTestProvider
-     * @throws \Exception
+     * @throws Exception
      */
     public function testCreateFromMinorUnits($expectedMoney, $amountInMinorUnits, $currency)
     {
@@ -405,10 +409,10 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
      * @param string $currency
      *
      * @dataProvider unsupportedCurrencyProvider
-     * @expectedException \InvalidArgumentException
      */
     public function testUnsupportedCurrency($amount, $currency)
     {
+        $this->expectException(InvalidArgumentException::class);
         new Money($amount, $currency);
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,6 @@
+<?php
+
+use Evp\Component\Money\Tests\MoneyComparator;
+use SebastianBergmann\Comparator\Factory;
+
+Factory::getInstance()->register(new MoneyComparator());


### PR DESCRIPTION
- Drop support for PHP 5.6
- Update [`phpunit/phpunit`](https://packagist.org/packages/phpunit/phpunit) to version `^6.5 || ^9.6`